### PR TITLE
[Bugfix] LCRoomMode 무한 스택 버그 수정

### DIFF
--- a/LastCanary/Source/LastCanary/Framework/PlayerController/LCRoomPlayerController.cpp
+++ b/LastCanary/Source/LastCanary/Framework/PlayerController/LCRoomPlayerController.cpp
@@ -24,15 +24,6 @@ void ALCRoomPlayerController::BeginPlay()
 	// TODO : Base Camp Level 에서 인터렉션 후 UI 표시
 	//CreateAndShowSelecetGameUI();
 	CreateAndShowRoomUI();
-
-	if (ULCGameInstanceSubsystem* Subsystem = GetGameInstance()->GetSubsystem<ULCGameInstanceSubsystem>())
-	{
-		if (ULCUIManager* UIManager = Subsystem->GetUIManager())
-		{
-			UIManager->InitUIManager(this);
-			UIManager->ShowInGameHUD();
-		}
-	}
 }
 
 void ALCRoomPlayerController::Client_UpdatePlayers_Implementation()


### PR DESCRIPTION
확인 결과 플레이어 캐릭터 생성 이전에 hud를 추가하는 과정에서 toolinventorycomponent가 할당되지 않아 발생한 문제로 확인되었습니다. 해당 문제는 beginplay 호출 순서에 따라 발생한 문제라서 지연을 통해 캐릭터가 생성된 뒤 hud가 추가되도록 수정하였습니다.