### PR TITLE
[Update] 캐릭터의 원격 메시에도 아이템 착용 추가

### DIFF
--- a/LastCanary/Content/_LastCanary/Dev/ItemTestMap.umap
+++ b/LastCanary/Content/_LastCanary/Dev/ItemTestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:130ebb9f36431b2c99e96c941ebff1562550beefef6ffe79b1316153f9783574
-size 80331
+oid sha256:50bb29821dc80381ff3f131bc173affdeb311cbf55e47bd590eb96b883e6842b
+size 81666

--- a/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.cpp
+++ b/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.cpp
@@ -26,6 +26,13 @@ UToolbarInventoryComponent::UToolbarInventoryComponent()
     EquippedItemComponent->SetUsingAbsoluteLocation(false);
     EquippedItemComponent->SetUsingAbsoluteRotation(false);
     EquippedItemComponent->SetUsingAbsoluteScale(false);
+
+    RemoteOnlyEquippedItemComponent = CreateDefaultSubobject<UChildActorComponent>(TEXT("RemoteOnlyEquippedItemComponent"));
+
+    RemoteOnlyEquippedItemComponent->SetIsReplicated(false);
+    RemoteOnlyEquippedItemComponent->SetUsingAbsoluteLocation(false);
+    RemoteOnlyEquippedItemComponent->SetUsingAbsoluteRotation(false);
+    RemoteOnlyEquippedItemComponent->SetUsingAbsoluteScale(false);
 }
 
 void UToolbarInventoryComponent::BeginPlay()
@@ -47,6 +54,12 @@ void UToolbarInventoryComponent::BeginPlay()
 
     EquippedItemComponent->AttachToComponent(
         CachedOwnerCharacter->GetMesh(),
+        AttachRules,
+        TEXT("Rifle")
+    );
+
+    RemoteOnlyEquippedItemComponent->AttachToComponent(
+        CachedOwnerCharacter->RemoteOnlySkeletalMesh,
         AttachRules,
         TEXT("Rifle")
     );
@@ -342,54 +355,11 @@ void UToolbarInventoryComponent::EquipItemAtSlot(int32 SlotIndex)
             TargetSocket = TEXT("Rifle");
         }
 
-        EquippedItemComponent->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+        SetupEquippedItem(EquippedItemComponent, CachedOwnerCharacter->GetMesh(),
+            TargetSocket, ItemData, SlotData);
 
-        FAttachmentTransformRules AttachRules(
-            EAttachmentRule::SnapToTarget,
-            EAttachmentRule::SnapToTarget,
-            EAttachmentRule::KeepWorld,
-            false
-        );
-
-        EquippedItemComponent->AttachToComponent(
-            CachedOwnerCharacter->GetMesh(),
-            AttachRules,
-            TargetSocket
-        );
-
-        EquippedItemComponent->SetChildActorClass(ItemData->ItemActorClass);
-
-        AItemBase* EquippedItem = Cast<AItemBase>(EquippedItemComponent->GetChildActor());
-        if (!EquippedItem)
-        {
-            LOG_Item_ERROR(TEXT("[ToolbarInventoryComponent::EquipItemAtSlot] ChildActor 생성 실패 또는 Cast 실패"));
-            return;
-        }
-
-        EquippedItem->SetOwner(GetOwner());
-        if (APawn* OwnerPawn = Cast<APawn>(GetOwner()))
-        {
-            EquippedItem->SetInstigator(OwnerPawn);
-        }
-
-        EquippedItem->ItemRowName = SlotData->ItemRowName;
-        EquippedItem->Quantity = SlotData->Quantity;
-        EquippedItem->Durability = SlotData->Durability;
-        EquippedItem->SetActorEnableCollision(false);
-
-        EquippedItem->ApplyItemDataFromTable();
-
-        if (AGunBase* Gun = Cast<AGunBase>(EquippedItem))
-        {
-            Gun->ApplyGunDataFromDataTable();
-        }
-
-        if (AEquipmentItemBase* EquipmentItem = Cast<AEquipmentItemBase>(EquippedItem))
-        {
-            EquipmentItem->SetEquipped(true);
-        }
-
-        EquippedItem->ForceNetUpdate();
+        SetupEquippedItem(RemoteOnlyEquippedItemComponent, CachedOwnerCharacter->RemoteOnlySkeletalMesh,
+            TargetSocket, ItemData, SlotData);
 
         ItemSlots[SlotIndex].bIsEquipped = true;
         CurrentEquippedSlotIndex = SlotIndex;
@@ -494,6 +464,7 @@ void UToolbarInventoryComponent::UnequipCurrentItem()
 
         // 아이템 제거
         EquippedItemComponent->DestroyChildActor();
+        RemoteOnlyEquippedItemComponent->DestroyChildActor();
     }
     else
     {
@@ -510,6 +481,7 @@ void UToolbarInventoryComponent::UnequipCurrentItem()
         }
 
         EquippedItemComponent->DestroyChildActor();
+        RemoteOnlyEquippedItemComponent->DestroyChildActor();
 
         CurrentEquippedSlotIndex = -1;
 
@@ -556,6 +528,61 @@ FBaseItemSlotData* UToolbarInventoryComponent::GetItemDataAtSlot(int32 SlotIndex
 int32 UToolbarInventoryComponent::GetCurrentEquippedSlotIndex() const
 {
     return CurrentEquippedSlotIndex;
+}
+
+void UToolbarInventoryComponent::SetupEquippedItem(UChildActorComponent* ItemComponent, USkeletalMeshComponent* TargetMesh, FName SocketName, FItemDataRow* ItemData, FBaseItemSlotData* SlotData)
+{
+    if (!ItemComponent || !TargetMesh || !ItemData || !SlotData)
+    {
+        return;
+    }
+
+    // 기존 아이템 해제
+    ItemComponent->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+
+    // 새 소켓에 연결
+    FAttachmentTransformRules AttachRules(
+        EAttachmentRule::SnapToTarget,
+        EAttachmentRule::SnapToTarget,
+        EAttachmentRule::KeepWorld,
+        false
+    );
+
+    ItemComponent->AttachToComponent(TargetMesh, AttachRules, SocketName);
+    ItemComponent->SetChildActorClass(ItemData->ItemActorClass);
+
+    // 아이템 설정
+    AItemBase* EquippedItem = Cast<AItemBase>(ItemComponent->GetChildActor());
+    if (!EquippedItem)
+    {
+        LOG_Item_ERROR(TEXT("[SetupEquippedItem] ChildActor 생성 실패"));
+        return;
+    }
+
+    EquippedItem->SetOwner(GetOwner());
+    if (APawn* OwnerPawn = Cast<APawn>(GetOwner()))
+    {
+        EquippedItem->SetInstigator(OwnerPawn);
+    }
+
+    EquippedItem->ItemRowName = SlotData->ItemRowName;
+    EquippedItem->Quantity = SlotData->Quantity;
+    EquippedItem->Durability = SlotData->Durability;
+    EquippedItem->SetActorEnableCollision(false);
+
+    EquippedItem->ApplyItemDataFromTable();
+
+    if (AGunBase* Gun = Cast<AGunBase>(EquippedItem))
+    {
+        Gun->ApplyGunDataFromDataTable();
+    }
+
+    if (AEquipmentItemBase* EquipmentItem = Cast<AEquipmentItemBase>(EquippedItem))
+    {
+        EquipmentItem->SetEquipped(true);
+    }
+
+    EquippedItem->ForceNetUpdate();
 }
 
 bool UToolbarInventoryComponent::CanAddItem(AItemBase* ItemActor)

--- a/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.h
+++ b/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.h
@@ -23,6 +23,13 @@ private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Equipment", meta = (AllowPrivateAccess = "true"))
     UChildActorComponent* EquippedItemComponent;
 
+    /** RemoteOnly 메시용 장착된 아이템 컴포넌트 */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Equipment", meta = (AllowPrivateAccess = "true"))
+    UChildActorComponent* RemoteOnlyEquippedItemComponent;
+
+    /** 특정 메시에 아이템 설정 */
+    void SetupEquippedItem(UChildActorComponent* ItemComponent, USkeletalMeshComponent* TargetMesh, FName SocketName, FItemDataRow* ItemData, FBaseItemSlotData* SlotData);
+
     /** 현재 장착된 슬롯 인덱스 */
     UPROPERTY(Replicated)
     int32 CurrentEquippedSlotIndex;


### PR DESCRIPTION
리슨 서버 환경에서 아이템을 장착할 때 개인 화면에서는 1인칭 메시에 아이템이 장착되지만 다른 사람의 화면에서는 3인칭 메시에 장착되는 경우가 발생하여 3인칭과 1인칭 둘 다 아이템이 장착되도록 추가했습니다.