### PR TITLE
[Feature] 평가 개선, 상점 플래그, 게이트 문 동작 추가 및 PIE SeamlessTravel 자동 허용

### DIFF
--- a/LastCanary/Content/StayLevel/Assect/BaseCamp_Assect/MOUT_Fabrication/Meshes/MOUTFabrications/Props/SM_AccessGate/AccessGateSplit/SM_Access_Gate_01_Split.uasset
+++ b/LastCanary/Content/StayLevel/Assect/BaseCamp_Assect/MOUT_Fabrication/Meshes/MOUTFabrications/Props/SM_AccessGate/AccessGateSplit/SM_Access_Gate_01_Split.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dadd6d34868530acc801a6e3abf4023e92c2e2238d76088082226d6c4be0aee8
-size 164995
+oid sha256:b7467871e4995bb796c690771cf05590c7cdfd1ee2bb327e29643e5e49fff22f
+size 236216

--- a/LastCanary/Content/StayLevel/BaseCamp.umap
+++ b/LastCanary/Content/StayLevel/BaseCamp.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a97fdc2eaf101d36495c81b8216dfa0f75c999044e44a23a524c1fbb58405982
-size 2954547
+oid sha256:973e68f31c4107ea166fff0d0b6ae8b8407cefedb0a872aa80563698df5c6ef8
+size 2949401

--- a/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_LCGateActor.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_LCGateActor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:326f6bcf6a8d6a813036a266cafe5562dbdd4f8bdbb38c8d30d5e480244aea5f
-size 26771
+oid sha256:874783629750b8aacefcc2d129cc391dc085cc63e1cba27d181a3fccdc8d7fbd
+size 27426

--- a/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_LCGateActor.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_LCGateActor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:874783629750b8aacefcc2d129cc391dc085cc63e1cba27d181a3fccdc8d7fbd
-size 27426
+oid sha256:07fab5cb3f2d9b47af5b4796895e7e56bec1ab639bfd85528f956b945f123969
+size 26771

--- a/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_PlayerChecker.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Actor/BP_PlayerChecker.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8dd95e2751323556b41309bb9eb09acc53cb7cdf0536cc999de14541b5963779
-size 23673
+oid sha256:a2b2684ce95c2eca58de406086be2beb9f8c83780b2df8f4d7e51d9b8e9e0dff
+size 39870

--- a/LastCanary/Content/_LastCanary/Blueprint/Actor/Curve_DoorOpen.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Actor/Curve_DoorOpen.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f9a4ed82901430ba5b7e572afe6b07d6d8aba82c57f3ea6c2aa2f3ea95a56c2
+size 4792

--- a/LastCanary/Content/_LastCanary/DataAsset/DataTable/DT_ItemData.uasset
+++ b/LastCanary/Content/_LastCanary/DataAsset/DataTable/DT_ItemData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f15bf73956857ec96bd2261bc50c0ea3fcc8f8bfa113b668b82155c93e334343
-size 14249
+oid sha256:b400b1a4ae423bb44b0beb84843a4c036283a53f88653a9ea56d727b51d639b1
+size 14257

--- a/LastCanary/Content/_LastCanary/Dev/InGameTestLevel.umap
+++ b/LastCanary/Content/_LastCanary/Dev/InGameTestLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da51fadc81e2986ee32c4e3c307f7e46291c3fa3967c44e62683d012218fa3ad
-size 183206
+oid sha256:a49823e6812f12a28533b12b4215a442717f5f82c394ca26644e8c9ca947dcb4
+size 192653

--- a/LastCanary/Source/LastCanary/Actor/PlayerChecker.cpp
+++ b/LastCanary/Source/LastCanary/Actor/PlayerChecker.cpp
@@ -3,14 +3,18 @@
 #include "GameFramework/PlayerState.h"
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
-
+#include "Components/StaticMeshComponent.h"
+#include "Components/TimelineComponent.h"
+#include "Character/BaseCharacter.h"
+#include "Net/UnrealNetwork.h"
+#include "Framework/GameState/LCGameState.h"
 #include "Framework/GameMode/LCGameMode.h"
 #include "DataType/SessionPlayerInfo.h"
 
-// Sets default values
 APlayerChecker::APlayerChecker()
 {
 	PrimaryActorTick.bCanEverTick = false;
+    bReplicates = true;
 
     // BoxComponent 생성 및 설정
     TriggerVolume = CreateDefaultSubobject<UBoxComponent>(TEXT("TriggerVolume"));
@@ -20,9 +24,15 @@ APlayerChecker::APlayerChecker()
     TriggerVolume->SetBoxExtent(FVector(200.f, 200.f, 100.f)); // 예시 크기
     RootComponent = TriggerVolume;
 
+    DoorTimeline = CreateDefaultSubobject<UTimelineComponent>(TEXT("DoorTimeline"));
+
+    LeftDoorMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("LeftDoorMesh"));
+    LeftDoorMesh->SetupAttachment(RootComponent);
+
+    RightDoorMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("RightDoorMesh"));
+    RightDoorMesh->SetupAttachment(RootComponent);
 }
 
-// Called when the game starts or when spawned
 void APlayerChecker::BeginPlay()
 {
 	Super::BeginPlay();
@@ -32,11 +42,37 @@ void APlayerChecker::BeginPlay()
         TriggerVolume->OnComponentBeginOverlap.AddDynamic(this, &APlayerChecker::OnOverlapBegin);
         TriggerVolume->OnComponentEndOverlap.AddDynamic(this, &APlayerChecker::OnOverlapEnd);
     }
+
+    if (DoorOpenCurve)
+    {
+        FOnTimelineFloat ProgressFunction;
+        ProgressFunction.BindUFunction(this, FName("HandleDoorProgress"));
+        DoorTimeline->AddInterpFloat(DoorOpenCurve, ProgressFunction);
+
+        FOnTimelineEvent TimelineFinished;
+        TimelineFinished.BindUFunction(this, FName("OnTimelineFinished"));
+        DoorTimeline->SetTimelineFinishedFunc(TimelineFinished);
+    }
+
+    InitialLeftRotation = LeftDoorMesh->GetRelativeRotation();
+    InitialRightRotation = RightDoorMesh->GetRelativeRotation();
+
+    //if (DoorTimeline && DoorOpenCurve)
+    //{
+    //    DoorTimeline->SetPlaybackPosition(0.f, false); // 열림 상태에서 시작
+    //    DoorTimeline->Stop(); // 처음에는 멈춘 상태
+    //    HandleDoorProgress(0.f); // 위치 보정
+    //}
+
+    bIsDoorOpen = true;
 }
 
 void APlayerChecker::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
-    if (!OtherActor) return;
+    if (!HasAuthority() || OtherActor == nullptr)
+    {
+        return;
+    }
 
     // Pawn인지, PlayerController가 붙어있는 Pawn인지 체크
     APawn* OverlappingPawn = Cast<APawn>(OtherActor);
@@ -72,7 +108,10 @@ void APlayerChecker::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor*
 
 void APlayerChecker::OnOverlapEnd(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex)
 {
-    if (!OtherActor) return;
+    if (!HasAuthority() || OtherActor == nullptr)
+    {
+        return;
+    }
 
     APawn* OverlappingPawn = Cast<APawn>(OtherActor);
     if (OverlappingPawn)
@@ -102,3 +141,83 @@ void APlayerChecker::OnOverlapEnd(UPrimitiveComponent* OverlappedComp, AActor* O
     }
 }
 
+void APlayerChecker::Server_OpenDoors_Implementation()
+{
+    if (bIsDoorOpen==false)
+    {
+        bIsDoorOpen = true;
+        OnRep_DoorState();
+        Multicast_OpenDoors();
+    }
+}
+
+void APlayerChecker::Server_CloseDoors_Implementation()
+{
+    if (bIsDoorOpen)
+    {
+        bIsDoorOpen = false;
+        OnRep_DoorState();
+        Multicast_CloseDoors();
+    }
+}
+
+void APlayerChecker::Multicast_OpenDoors_Implementation()
+{
+    PlayDoorTimelineForward();
+}
+
+void APlayerChecker::Multicast_CloseDoors_Implementation()
+{
+    PlayDoorTimelineReverse();
+}
+
+void APlayerChecker::PlayDoorTimelineForward()
+{
+    if (DoorTimeline && DoorOpenCurve)
+    {
+        DoorTimeline->Play();
+    }
+}
+
+void APlayerChecker::PlayDoorTimelineReverse()
+{
+    if (DoorTimeline && DoorOpenCurve)
+    {
+        DoorTimeline->Reverse();
+    }
+}
+
+void APlayerChecker::OnRep_DoorState()
+{
+    if (bIsDoorOpen)
+    {
+        // 클라이언트에서 들어올 때도 재생
+        PlayDoorTimelineForward();
+    }
+    else
+    {
+        PlayDoorTimelineReverse();
+    }
+}
+
+void APlayerChecker::HandleDoorProgress(float Value)
+{
+    // 문을 부드럽게 열기
+    const FRotator NewLeftRotation = InitialLeftRotation + FRotator(0.f, -DoorOpenAngle * Value, 0.f);
+    const FRotator NewRightRotation = InitialRightRotation + FRotator(0.f, DoorOpenAngle * Value, 0.f);
+
+    LeftDoorMesh->SetRelativeRotation(NewLeftRotation);
+    RightDoorMesh->SetRelativeRotation(NewRightRotation);
+}
+
+void APlayerChecker::OnTimelineFinished()
+{
+    // 열림 완료 처리 또는 사운드 추가
+}
+
+void APlayerChecker::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(APlayerChecker, bIsDoorOpen);
+}

--- a/LastCanary/Source/LastCanary/Actor/PlayerChecker.h
+++ b/LastCanary/Source/LastCanary/Actor/PlayerChecker.h
@@ -5,7 +5,9 @@
 #include "PlayerChecker.generated.h"
 
 class UBoxComponent;
-
+class UTimelineComponent;
+class UCurveFloat;
+class UStaticMeshComponent;
 
 UCLASS()
 class LASTCANARY_API APlayerChecker : public AActor
@@ -35,4 +37,60 @@ protected:
         UPrimitiveComponent* OtherComp,
         int32 OtherBodyIndex);
 
+protected:
+	// 문 관련 변수 및 함수
+    UPROPERTY(VisibleAnywhere, Category = "Door")
+	UStaticMeshComponent* LeftDoorMesh;
+    UPROPERTY(VisibleAnywhere, Category = "Door")
+	UStaticMeshComponent* RightDoorMesh;
+
+    UPROPERTY(EditAnywhere, Category = "Door|Animation")
+    UCurveFloat* DoorOpenCurve;
+
+    UPROPERTY()
+    UTimelineComponent* DoorTimeline;
+
+    UPROPERTY()
+    FRotator InitialLeftRotation;
+
+    UPROPERTY()
+    FRotator InitialRightRotation;
+
+    UPROPERTY(ReplicatedUsing = OnRep_DoorState)
+    bool bIsDoorOpen;
+
+	UFUNCTION()
+    void OnRep_DoorState();
+
+    UPROPERTY(EditAnywhere, Category = "Door|Animation")
+    float DoorOpenAngle = 90.f;
+
+    UFUNCTION()
+    void HandleDoorProgress(float Value);
+
+    UFUNCTION()
+    void OnTimelineFinished();
+
+public:
+    // Server 호출 → 클라이언트에 전파
+    UFUNCTION(Server, Reliable)
+    void Server_OpenDoors();
+    void Server_OpenDoors_Implementation();
+
+    UFUNCTION(Server, Reliable)
+    void Server_CloseDoors();
+	void Server_CloseDoors_Implementation();
+
+    UFUNCTION(NetMulticast, Reliable)
+    void Multicast_OpenDoors();
+    void Multicast_OpenDoors_Implementation();
+
+    UFUNCTION(NetMulticast, Reliable)
+    void Multicast_CloseDoors();
+	void Multicast_CloseDoors_Implementation();
+
+    void PlayDoorTimelineForward();   // 열기
+    void PlayDoorTimelineReverse();   // 닫기
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const;
 };

--- a/LastCanary/Source/LastCanary/DataTable/ItemDataRow.h
+++ b/LastCanary/Source/LastCanary/DataTable/ItemDataRow.h
@@ -26,8 +26,6 @@ struct FItemDataRow : public FTableRowBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FText ItemDescription = FText::FromString(TEXT(""));
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	bool bSellInShop = true;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	bool bCanBuy = true;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 MaxStack = 1;

--- a/LastCanary/Source/LastCanary/DataTable/ItemDataRow.h
+++ b/LastCanary/Source/LastCanary/DataTable/ItemDataRow.h
@@ -42,6 +42,8 @@ struct FItemDataRow : public FTableRowBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	USkeletalMesh* SkeletalMesh = nullptr;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UMaterialInterface* OverrideMaterial = nullptr;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TSubclassOf<AItemBase> ItemActorClass;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Resource")

--- a/LastCanary/Source/LastCanary/Framework/GameInstance/LCGameInstanceSubsystem.cpp
+++ b/LastCanary/Source/LastCanary/Framework/GameInstance/LCGameInstanceSubsystem.cpp
@@ -21,6 +21,19 @@ void ULCGameInstanceSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		GI->LoadItemData();
 		GI->LoadGunData();
 	}
+
+
+#if WITH_EDITOR
+	if (GEngine)
+	{
+		UWorld* World = GetWorld();
+		if (World)
+		{
+			GEngine->Exec(World, TEXT("net.AllowPIESeamlessTravel 1"));
+			UE_LOG(LogTemp, Warning, TEXT("[LCGameInstanceSubsystem] PIE SeamlessTravel enabled."));
+		}
+	}
+#endif
 }
 
 ULCUIManager* ULCGameInstanceSubsystem::GetUIManager() const

--- a/LastCanary/Source/LastCanary/Item/EquipmentItem/FlashlightItem.cpp
+++ b/LastCanary/Source/LastCanary/Item/EquipmentItem/FlashlightItem.cpp
@@ -11,7 +11,7 @@ AFlashlightItem::AFlashlightItem()
 {
     // 스포트라이트 컴포넌트 생성
     SpotLightComponent = CreateDefaultSubobject<USpotLightComponent>(TEXT("SpotLight"));
-    SpotLightComponent->SetupAttachment(MeshComponent);
+    SpotLightComponent->SetupAttachment(StaticMeshComponent);
 
     // 네트워크 복제 활성화
     SpotLightComponent->SetIsReplicated(true);

--- a/LastCanary/Source/LastCanary/Item/ItemBase.h
+++ b/LastCanary/Source/LastCanary/Item/ItemBase.h
@@ -27,7 +27,7 @@ public:
 
     /** 아이템의 스태틱 메시 컴포넌트 */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
-    UStaticMeshComponent* MeshComponent;
+    UStaticMeshComponent* StaticMeshComponent;
 
     /** 아이템의 스켈레탈 메시 컴포넌트 */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")

--- a/LastCanary/Source/LastCanary/UI/UIElement/ShopWidget.cpp
+++ b/LastCanary/Source/LastCanary/UI/UIElement/ShopWidget.cpp
@@ -31,7 +31,7 @@ void UShopWidget::NativeConstruct()
 	{
 		ItemInfoWidget->SetShoppingCartWidget(ShoppingCartWidget);
 	}
-	
+
 	if (ShoppingCartWidget)
 	{
 		// 골드 가져오기 
@@ -85,7 +85,7 @@ void UShopWidget::PopulateShopItems()
 	{
 		if (const FItemDataRow* ItemData = ItemDataTable->FindRow<FItemDataRow>(RowName, TEXT("Shop Load")))
 		{
-			if (!ItemData->bSellInShop)
+			if (ItemData->bCanBuy == false)
 			{
 				continue;
 			}


### PR DESCRIPTION
✅ 상점 위젯에서 아이템이 상점 판매 대상인지 여부 (bCanBuy)를 UI에서 체크 및 필터링 처리

✅ 베이스캠프 게이트 앞 문 동작 로직 추가

- 문은 기본적으로 열려 있음

- 모든 플레이어가 트리거에 도착하면 닫힘

- 닫히는 도중 다시 나가면 다시 열림

✅ 자원 평가 시 bIsResourceItem 기반 필터링 적용

- 기존 하드코딩된 ResourceIDMapping 제거

- ItemDataTable 기반으로 자원 자동 파싱

✅ ItemDataTable에 OverrideMaterial 추가

- 머티리얼이 설정되어 있으면 해당 머티리얼을 스폰된 아이템 메시 컴포넌트에 적용

- 설정이 없으면 아무 것도 하지 않음

✅ ULCGameInstanceSubsystem::Initialize() 내부에 PIE 환경 자동 설정 추가

- net.AllowPIESeamlessTravel 1을 자동으로 실행하여 개발 편의성 향상

💬 기타
- ItemSpawner, ChecklistManager, ItemBase 등 관련 클래스에 수정이 포함됨

- WITH_EDITOR 분기를 통해 패키징된 빌드에는 영향 없음

