### PR TITLE
[Bugfix] 인벤토리 리팩토링 과정에서 발생한 문제 수정

### DIFF
--- a/LastCanary/Content/_LastCanary/Blueprint/Character/BP_LCDefaultCharacter.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Character/BP_LCDefaultCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd83b32753e63871a71a964d79202ae979fee33b2da6ce88f653cbc4c91427e0
-size 400404
+oid sha256:63b0073ca71aee55073f46336cf8fb79d674cc56bc9290a4c5db7fdd4ea9adeb
+size 398024

--- a/LastCanary/Content/_LastCanary/Blueprint/Inventory/DA_DefaultInventoryConfig.uasset
+++ b/LastCanary/Content/_LastCanary/Blueprint/Inventory/DA_DefaultInventoryConfig.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:341ac15bc1e21381c3445c075913dce1861c48806924f4bac6ff299fbe5ca4c1
+size 1475

--- a/LastCanary/Source/LastCanary/Inventory/InventoryComponentBase.cpp
+++ b/LastCanary/Source/LastCanary/Inventory/InventoryComponentBase.cpp
@@ -69,7 +69,7 @@ void UInventoryComponentBase::InitializeSlots()
 {
 	if (!GetInventoryConfig())
 	{
-		UE_LOG(LogTemp, Error, TEXT("[InitializeSlots] InventoryConfig가 null입니다!"));
+		LOG_Item_WARNING(TEXT("[InitializeSlots] InventoryConfig가 null입니다!"));
 		return;
 	}
 
@@ -319,7 +319,25 @@ bool UInventoryComponentBase::IsWalkieTalkieItem(FName ItemRowName) const
 
 const UInventoryConfig* UInventoryComponentBase::GetInventoryConfig() const
 {
-	return InventoryConfig; // nullptr이어도 유틸리티에서 기본값 처리
+	if (InventoryConfig)
+	{
+		return InventoryConfig;
+	}
+
+	// 없을 경우 기본 설정을 반환하거나 생성
+	static UInventoryConfig* DefaultConfig = nullptr;
+	if (!DefaultConfig)
+	{
+		DefaultConfig = NewObject<UInventoryConfig>();
+		// 기본값들 설정
+		DefaultConfig->DefaultItemRowName = FName("Default");
+		DefaultConfig->DefaultBackpackSlots = 20;
+		DefaultConfig->DropDistanceFromPlayer = 150.0f;
+		DefaultConfig->MinDropHeight = 80.0f;
+		DefaultConfig->DefaultDurability = 100.0f;
+	}
+
+	return DefaultConfig;
 }
 
 bool UInventoryComponentBase::IsDefaultItem(FName ItemRowName) const

--- a/LastCanary/Source/LastCanary/Inventory/InventoryComponentBase.h
+++ b/LastCanary/Source/LastCanary/Inventory/InventoryComponentBase.h
@@ -70,7 +70,7 @@ public:
 
     /** 인벤토리 설정 */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Inventory|Config")
-    UInventoryConfig* InventoryConfig;
+    UInventoryConfig* InventoryConfig = nullptr;
 
     /** 설정 가져오기 (없으면 기본값) */
     const UInventoryConfig* GetInventoryConfig() const;

--- a/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.h
+++ b/LastCanary/Source/LastCanary/Inventory/ToolbarInventoryComponent.h
@@ -223,6 +223,8 @@ protected:
     void Multicast_SetBackpackVisibility_Implementation(bool bVisible);
 
     /** 델리게이트 핸들러 */
+    UFUNCTION()
     void OnBackpackEquippedHandler(const TArray<FBackpackSlotData>& BackpackSlots);
+    UFUNCTION()
     void OnBackpackUnequippedHandler();
 };

--- a/LastCanary/Source/LastCanary/UI/UIElement/ToolbarInventoryWidget.cpp
+++ b/LastCanary/Source/LastCanary/UI/UIElement/ToolbarInventoryWidget.cpp
@@ -32,14 +32,21 @@ void UToolbarInventoryWidget::RefreshInventoryUI()
         return;
     }
 
-    ToolbarSlotBox->ClearChildren();
-
     UToolbarInventoryComponent* ToolbarInventory = Cast<UToolbarInventoryComponent>(InventoryComponent);
     if (!ToolbarInventory)
     {
         LOG_Item_WARNING(TEXT("[ToolbarInventoryWidget::RefreshInventoryUI] InventoryComponent 캐스팅 실패!"));
         return;
     }
+
+    // ItemSlots가 아직 초기화되지 않았으면 중단
+    if (ToolbarInventory->ItemSlots.Num() == 0)
+    {
+        LOG_Item_WARNING(TEXT("[ToolbarInventoryWidget::RefreshInventoryUI] ItemSlots가 아직 초기화되지 않음"));
+        return;
+    }
+
+    ToolbarSlotBox->ClearChildren();
 
     for (int32 i = 0; i < ToolbarInventory->GetMaxSlots(); ++i)
     {


### PR DESCRIPTION
[호출 순서 문제로 초기화되지 않은 인벤토리가 호출되어 발생한 문제 수정]
- 아직 인벤토리가 초기화되지 않았다면 새로고침을 중단하도록 하였습니다.

[InventoryConfig가 Null이 되는 문제, 핸들러 함수에서 오류 발생]
1. 데이터 에셋을 생성해 캐릭터에게 할당하였습니다.
2. 델리게이트 핸들러 함수의 선언에 UFUNCTION 가 빠져있어서 발생한 문제입니다.